### PR TITLE
Add FBS support for ahci-dwc controller

### DIFF
--- a/drivers/ata/ahci_dwc.c
+++ b/drivers/ata/ahci_dwc.c
@@ -204,6 +204,9 @@ static void ahci_dwc_check_cap(struct ahci_host_priv *hpriv)
 		dev_warn(&dpriv->pdev->dev, "PMPn is limited up to %u ports\n",
 			 fbs_pmp);
 	}
+	
+	if (fbs_sup)
+			hpriv->flags |= AHCI_HFLAG_YES_FBS;
 
 	for_each_set_bit(i, &port_map, AHCI_MAX_PORTS) {
 		if (!dev_mp && hpriv->saved_port_cap[i] & PORT_CMD_MPSP) {


### PR DESCRIPTION
众所不周知，JMB575有基于端口的交换和基于命令的交换，但驱动里写死了ahci-dwc没有FBS能力，因此导致了基于端口的交换、单盘读写性能正常、多盘性能与单盘一致 ~~、任意一块盘挂掉会导致整个pm掉线~~

因此 call claude 修好了这个事情，使驱动从readonly register读取FBS能力并报告给libahci以启动FBS，按道理也能在其他的dwc控制器中使用，但手头只有rk3566能亮以及需要亮。

截图：
patch前：
<details>
<summary><del>单一掉盘导致PM离线：</del>（看起来不是因为PM引起，patch后一样的爆炸，要调别的地方）</summary>
<img width="1099" height="1242" alt="image" src="https://github.com/user-attachments/assets/c9c685d8-1c5f-4ec2-94cb-c9a347654b00" />
```dmesg
[  166.395218] ata1.01: SATA link down (SStatus 0 SControl 330)
[  171.765528] ata1.01: SATA link down (SStatus 0 SControl 330)
[  171.765696] ata1.01: limiting SATA link speed to <unknown>
[  177.100657] ata1.01: SATA link down (SStatus 0 SControl 330)
[  177.100847] ata1.01: disable device
[  177.101053] ata1: PMP SError.N set for some ports, repeating recovery
[  177.101173] ata1.02: hard resetting link
[  181.918703] ata1.02: SATA link up 6.0 Gbps (SStatus 133 SControl 330)
[  181.919041] ata1.02: failed to IDENTIFY (I/O error, err_mask=0x100)
[  181.919087] ata1.15: hard resetting link
[  182.390938] ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  182.392143] ata1.00: hard resetting link
[  182.709124] ata1.00: SATA link down (SStatus 0 SControl 330)
[  182.709417] ata1.01: hard resetting link
[  183.025451] ata1.01: SATA link down (SStatus 0 SControl 330)
[  187.027445] ata1.02: hard resetting link
[  197.031222] ata1.02: softreset failed (1st FIS failed)
[  197.031296] ata1.02: failed to read SCR 0 (Emask=0x40)
[  197.031325] ata1.02: reset failed, giving up
[  197.031345] ata1.02: failed to recover link after 3 tries, disabling
[  197.031377] ata1.15: hard resetting link
[  197.497129] ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  197.813599] ata1.02: failed to write SCR 1 (Emask=0x100)
[  197.813708] ata1.02: COMRESET failed (errno=-5)
[  197.813736] ata1.02: failed to write SCR 1 (Emask=0x40)
[  197.813758] ata1.02: failed to clear SError.N (errno=-5)
[  197.813786] ata1.15: hard resetting link
[  198.280439] ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  198.597537] ata1.02: failed to write SCR 1 (Emask=0x100)
[  198.597600] ata1.02: COMRESET failed (errno=-5)
[  198.597624] ata1.02: failed to write SCR 1 (Emask=0x40)
[  198.597646] ata1.02: failed to clear SError.N (errno=-5)
[  198.597674] ata1.15: hard resetting link
[  199.070424] ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  199.387339] ata1.02: failed to write SCR 1 (Emask=0x100)
[  199.387403] ata1.02: COMRESET failed (errno=-5)
[  199.387426] ata1.02: failed to write SCR 1 (Emask=0x40)
[  199.387448] ata1.02: failed to clear SError.N (errno=-5)
[  199.387477] ata1.15: hard resetting link
[  199.860332] ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  200.173478] ata1.02: failed to write SCR 1 (Emask=0x100)
[  200.173543] ata1.02: COMRESET failed (errno=-5)
[  200.173642] ata1.02: failed to write SCR 1 (Emask=0x40)
[  200.173674] ata1.02: failed to clear SError.N (errno=-5)
[  200.173698] ata1: failed to recover PMP after 5 tries, giving up
[  200.173719] ata1.15: Port Multiplier detaching
[  200.173750] ata1.03: Entering standby power mode
[  200.173771] ata1.03: STANDBY IMMEDIATE failed (err_mask=0x40)
[  200.173791] ata1.03: disable device
[  200.173814] ata1.04: Entering standby power mode
[  200.173833] ata1.04: STANDBY IMMEDIATE failed (err_mask=0x40)
[  200.173852] ata1.04: disable device
[  200.173873] ata1.00: disable device
[  200.640380] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[  200.640495] ata1: EH complete
[  200.640573] ata1.01: detaching (SCSI 0:1:0:0)
[  200.683832] sd 0:1:0:0: [sdb] Synchronizing SCSI cache
[  200.684162] sd 0:1:0:0: [sdb] Synchronize Cache(10) failed: Result: hostbyte=0x04 driverbyte=DRIVER_OK
[  200.697506] ata1.03: detaching (SCSI 0:3:0:0)
[  200.770490] sd 0:3:0:0: [sdc] Synchronizing SCSI cache
[  200.770726] sd 0:3:0:0: [sdc] Synchronize Cache(10) failed: Result: hostbyte=0x04 driverbyte=DRIVER_OK
[  200.787501] ata1.04: detaching (SCSI 0:4:0:0)
[  200.870541] sd 0:4:0:0: [sda] Synchronizing SCSI cache
[  200.870912] sd 0:4:0:0: [sda] Synchronize Cache(10) failed: Result: hostbyte=0x04 driverbyte=DRIVER_OK
```
</details>
需要通过去掉坏盘、执行`echo "- - -" > /sys/class/scsi_host/host0/scan`来恢复

多盘速度测试：
<img width="490" height="179" alt="image" src="https://github.com/user-attachments/assets/389b12de-ad5f-4d04-9818-1bf5a33e3e9b" />


patch后： (`armbian-update -u rk35xx -r LXY1226/kernel`)
<img width="530" height="190" alt="image" src="https://github.com/user-attachments/assets/a9bce83c-ff84-4d9a-b167-b8692c144269" />
<img width="707" height="537" alt="IMG_20260420_094100" src="https://github.com/user-attachments/assets/412bf43e-aa25-465d-83af-6c6eb39ba945" />



（最后发现掉盘是那个盘位有问题、换一个盘位就都不会爆炸了，后续再物理修修，但之前先想办法调整一下不让一个爆炸影响其他）